### PR TITLE
solution to the problem: new tables are not created during rotation

### DIFF
--- a/src/Service/Rotation/Rotator.php
+++ b/src/Service/Rotation/Rotator.php
@@ -60,8 +60,7 @@ final class Rotator implements RotatorInterface
         string $tableName,
         RotationConfig $config,
         AbstractSchemaManager $schemaManager,
-    ): string
-    {
+    ): string {
         $newTableName = $tableName . '_' . date($config->dateFormat);
 
         $schemaManager->renameTable($tableName, $newTableName);

--- a/src/Service/Rotation/Rotator.php
+++ b/src/Service/Rotation/Rotator.php
@@ -32,9 +32,10 @@ final class Rotator implements RotatorInterface
 
         try {
             $this->connection->beginTransaction();
+            $schemaManager = $this->getSchemaManager();
             foreach ($tables as $table) {
-                $result[] = $this->renameTable($table, $config);
-                $result[] = $this->tableCreator->create($table);
+                $result[] = $this->renameTable($table, $config, $schemaManager);
+                $result[] = $this->tableCreator->create($table, $schemaManager);
                 array_push($result, ...$this->deleteOldVersions($table, $config));
             }
 
@@ -51,12 +52,16 @@ final class Rotator implements RotatorInterface
 
     /**
      * @param string $tableName
+     * @param AbstractSchemaManager $schemaManager
      * @return string
      * @throws Exception
      */
-    private function renameTable(string $tableName, RotationConfig $config): string
+    private function renameTable(
+        string $tableName,
+        RotationConfig $config,
+        AbstractSchemaManager $schemaManager,
+    ): string
     {
-        $schemaManager = $this->getSchemaManager();
         $newTableName = $tableName . '_' . date($config->dateFormat);
 
         $schemaManager->renameTable($tableName, $newTableName);

--- a/src/Service/TableCreation/TableCreator.php
+++ b/src/Service/TableCreation/TableCreator.php
@@ -25,14 +25,16 @@ final class TableCreator implements TableCreatorInterface
     }
 
     /**
-     * @param string $name
+     * @param string                     $name
+     * @param AbstractSchemaManager|null $schemaManager
+     *
      * @return string
      * @throws TableCreationException
      */
-    public function create(string $name): string
+    public function create(string $name, ?AbstractSchemaManager $schemaManager = null): string
     {
         try {
-            $schemaManager = $this->getSchemaManager();
+            $schemaManager = $schemaManager ?? $this->getSchemaManager();
 
             $table = $this->getTableInstance($name);
 

--- a/src/Service/TableCreation/TableCreatorInterface.php
+++ b/src/Service/TableCreation/TableCreatorInterface.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace Exbico\MonologDbBundle\Service\TableCreation;
 
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+
 interface TableCreatorInterface
 {
     /**
-     * @param string $name
+     * @param string                     $name
+     * @param AbstractSchemaManager|null $schemaManager
+     *
      * @return string
      * @throws TableCreationException
      */
-    public function create(string $name): string;
+    public function create(string $name, ?AbstractSchemaManager $schemaManager = null): string;
 }


### PR DESCRIPTION
In version 2.0, new tables are not created during rotation, because renaming and creating new tables is wrapped in a transaction, and Connection now does not store the state of the schema manager, but creates it each time. So in TableCreator the !$schemaManager->tablesExist($name) check fails and tables are not created